### PR TITLE
Pass optional metadata to method calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,6 @@ function printClient(f: GeneratedFile, service: DescService, packageName: string
   const Injectable = f.import("Injectable", "@nestjs/common");
   const Inject = f.import("Inject", "@nestjs/common");
   const ClientGrpc = f.import("ClientGrpc", "@nestjs/microservices");
-  // f.print("import { Metadata } from '@grpc/grpc-js';");
 
 
   f.print()

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ function printMethod(f: GeneratedFile, method: DescMethod) {
   const Observable = f.import("Observable", "rxjs");
   const inputType = f.importShape(method.input);
   const outputType = f.importShape(method.output);
+  const Metadata = f.import("Metadata", "@grpc/grpc-js");
 
   const isStreamReq = ['bidi_streaming', 'client_streaming'].includes(method.methodKind);
   const isStreamRes = method.methodKind !== 'unary';
@@ -74,7 +75,7 @@ function printMethod(f: GeneratedFile, method: DescMethod) {
   const resType = isStreamRes ? [Observable, "<", outputType, ">"] : ["Promise<", outputType, ">"];
 
   f.print(f.jsDoc(method, "  "));
-  f.print`  ${method.localName}(request: ${reqType}): ${resType};`;
+  f.print`  ${method.localName}(request: ${reqType}, metadata?: ${Metadata}): ${resType};`;
 }
 
 function printGrpcMethodAnnotations(
@@ -96,6 +97,7 @@ function printClientMethod(f: GeneratedFile, method: DescMethod) {
   const firstValueFrom = f.import("firstValueFrom", "rxjs");
   const inputType = f.importShape(method.input);
   const outputType = f.importShape(method.output);
+  const Metadata = f.import("Metadata", "@grpc/grpc-js");
 
   const isStreamReq = ['bidi_streaming', 'client_streaming'].includes(method.methodKind);
   const isStreamRes = method.methodKind !== 'unary';
@@ -105,12 +107,12 @@ function printClientMethod(f: GeneratedFile, method: DescMethod) {
   const resType = isStreamRes ? [Observable, "<", outputType, ">"] : ["Promise<", outputType, ">"];
 
   f.print(f.jsDoc(method, "  "));
-  f.print`  ${method.localName}(request: ${reqType}): ${resType} {`;
+  f.print`  ${method.localName}(request: ${reqType}, metadata = new ${Metadata}()): ${resType} {`;
 
   if (isStreamRes) {
-    f.print("    return this.client.", method.localName, "(request);");
+    f.print("    return this.client.", method.localName, "(request, metadata);");
   } else {
-    f.print("    return ", firstValueFrom, "(this.client.", method.localName, "(request));");
+    f.print("    return ", firstValueFrom, "(this.client.", method.localName, "(request, metadata));");
   }
 
   f.print("  }")
@@ -125,6 +127,8 @@ function printClient(f: GeneratedFile, service: DescService, packageName: string
   const Injectable = f.import("Injectable", "@nestjs/common");
   const Inject = f.import("Inject", "@nestjs/common");
   const ClientGrpc = f.import("ClientGrpc", "@nestjs/microservices");
+  // f.print("import { Metadata } from '@grpc/grpc-js';");
+
 
   f.print()
 
@@ -137,7 +141,7 @@ function printClient(f: GeneratedFile, service: DescService, packageName: string
   f.print("export class ", safeIdentifier(service.name), "Client implements ", OnModuleInit, ", ", Controller, " {");
   f.print()
 
-  f.print("private client: any; //I Know, it's because of nestjs/microservice insisting one verything being observables");
+  f.print("private client: any; //I Know, it's because of nestjs/microservice insisting one everything being observables");
   f.print()
 
   f.print("constructor(@", Inject, "(INJECTED_", safeIdentifier(service.name).toUpperCase(), "_PACKAGE) ", "private grpc: ", ClientGrpc, ") {}");


### PR DESCRIPTION
```
  * @generated from rpc ccode.Workspace.InitProject
   */
  initProject(request: InitRequest, metadata = new Metadata()): Promise<ResponseCode> {
    return firstValueFrom(this.client.initProject(request, metadata));
  }

  /**
   * @generated from rpc ccode.Workspace.NewWorkspace
   */
  newWorkspace(request: NewWorkspaceRequest, metadata = new Metadata()): Promise<WorkspaceSession> {
    return firstValueFrom(this.client.newWorkspace(request, metadata));
  }
```